### PR TITLE
Use scontrol to get job stdout path

### DIFF
--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -271,15 +271,15 @@ export class JobQueueProvider implements vscode.TreeDataProvider<JobItem|InfoIte
      * @param jobItem The job item.
      */
     private showOutput(jobItem: JobItem): void {
-        if (jobItem.job.outputFile) {
-            const fpath = resolvePathRelativeToWorkspace(jobItem.job.outputFile);
-            vscode.workspace.openTextDocument(fpath).then((doc) => {
+        const fpath = this.scheduler.getJobOutputPath(jobItem.job);
+        if (fpath) {
+            vscode.workspace.openTextDocument(resolvePathRelativeToWorkspace(fpath)).then((doc) => {
                 vscode.window.showTextDocument(doc);
             }, (error) => {
                 vscode.window.showErrorMessage(`Failed to open output file ${jobItem.job.outputFile}.\n${error}`);
             });
         } else {
-            vscode.window.showErrorMessage(`Job ${jobItem.job.id} has no associated batch file.`);
+            vscode.window.showErrorMessage(`Job ${jobItem.job.id} has no associated output file.`);
         }
     }
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -119,6 +119,14 @@ export interface Scheduler {
      */
     submitJob(jobScript: string|vscode.Uri): void;
 
+    /**
+     * Retrieve the output path for a job file. Is permitted to simply return 
+     * job.outputFile. Returns undefined if the job does not have an output file.
+     * @param job The job for which to retrieve the output path.
+     * @returns The output path for the job or undefined if the job does not have an output file.
+     */
+    getJobOutputPath(job: Job): string|undefined;
+
 }
 
 /**
@@ -281,11 +289,10 @@ export class SlurmScheduler implements Scheduler {
                 results["State"],
                 results["Partition"],
                 results["Command"],
-                results["STDOUT"],
+                undefined,  /* let this be filled in by getJobOutputPath later */
                 WallTime.fromString(results["TimeLimit"]),
                 WallTime.fromString(results["TimeUsed"])
             );
-            job.outputFile = this.getJobOutputPath(job);
             jobs.push(job);
         });
 
@@ -294,25 +301,52 @@ export class SlurmScheduler implements Scheduler {
 
     /**
      * Finds the path for the standard output file of a job.
-     * If the job does not have an output file, returns undefined.
-     * Uses scontrol to find the output file.
+     * Returns job.outputFile if it is already defined.
+     * Otherwise uses scontrol to find the output file.
      * 
      * @param job The job for which to resolve the stdout path.
      * @returns The resolved stdout path or undefined if the job does not have an output file.
      */
-    private getJobOutputPath(job: Job): string|undefined {
-        const command = `scontrol show job ${job.id} | grep StdOut | cut -d= -f2`;
+    public getJobOutputPath(job: Job): string|undefined {
+        /* early exit if it's already defined */
+        if (job.outputFile) {
+            return job.outputFile;
+        }
+
+        const command = `scontrol show job ${job.id}`;
 
         try {
             const output = execSync(command).toString().trim();
-            return output;
-        }
-        catch (error) {
+
+            /* find line that starts with StdOut */
+            const lines = output.split("\n");
+            let stdoutLine: string|undefined = undefined;
+            for (let line of lines) {
+                if (line.trim().startsWith("StdOut=")) {
+                    stdoutLine = line.trim();
+                    break;
+                }
+            }
+
+            /* if we didn't find a line, return undefined */
+            if (!stdoutLine) {
+                throw new Error(`Failed to find stdout line in output: ${output}`);
+            }
+
+            /* extract path from line: StdOut=/path/to/file */
+            const parts = stdoutLine.split("=");
+            if (parts.length < 2) {
+                throw new Error(`Failed to parse stdout line: ${stdoutLine}`);
+            }
+            const fpath = parts[1].trim();
+
+            job.outputFile = fpath;
+            return fpath;
+        } catch (error) {
             vscode.window.showErrorMessage(`Failed to get job output path for job ${job.id}.\nError: ${error}`);
             return undefined;
         }
     }
-
 
 }
 
@@ -357,6 +391,16 @@ export class Debug implements Scheduler {
     public submitJob(jobScript: string|vscode.Uri): void {
         vscode.window.showInformationMessage(`Submit job ${jobScript}`);
     }
+
+    /**
+     * For the debug scheduler, just returns the job's output file.
+     * @param job The job for which to retrieve the output path.
+     * @returns The output path for the job or undefined if the job does not have an output file.
+     */
+    public getJobOutputPath(job: Job): string|undefined {
+        return job.outputFile;
+    }
+
 }
 
 /**

--- a/src/test/suite/scheduler.test.ts
+++ b/src/test/suite/scheduler.test.ts
@@ -167,7 +167,17 @@ suite('scheduler.ts tests', () => {
         let debug = new scheduler.Debug();
 
         assert.doesNotThrow(() => debug.submitJob("job1.sh"));
-    }); 
+    });
+
+    test('Debug :: getJobOutput', () => {
+        let debug = new scheduler.Debug();
+
+        debug.getQueue().then((jobs: scheduler.Job[]) => {
+            jobs.forEach((job: scheduler.Job) => {
+                assert.strictEqual(job.outputFile, debug.getJobOutputPath(job));
+            });
+        });
+    });
 
     test('getScheduler', async () => {
         let config = vscode.workspace.getConfiguration("slurm-dashboard");


### PR DESCRIPTION
The current way of finding a jobs stdout file path fails if there are string replacements other than `%A` in the output path string, such as `%a` in job arrays. Manually replacing all possible placeholders would be tedious, and there are some tricky edge cases (e.g. `%a` in a non-array job). I propose using `scontrol` to find the stdout path of a job instead.

PS: This project is awesome! I've been wanting something exactly like this for a while. 