### PR TITLE
Fix for large squeue outputs

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { execSync, exec, execFileSync } from 'child_process';
+import { execSync, execFileSync, spawn } from 'child_process';
 import { WallTime } from './time';
 import { getParentDirectory } from './fileutilities';
 import { returnIfNoThrow } from './util';
@@ -300,12 +300,21 @@ export class SlurmScheduler implements Scheduler {
     private getQueueOutput(): Thenable<string | undefined> {
         const columnsString = this.columns.join(',');
         const userFilterArg = this.getUserFilterArgForSqueue();
-        const command = `squeue ${userFilterArg} --noheader -O ${columnsString}`;
 
         return new Promise((resolve, reject) => {
-            exec(command, (error, stdout, stderr) => {
-                if (error) {
-                    reject(error);
+            const squeue = spawn('squeue', [userFilterArg, '--noheader', '-O', columnsString]);
+            const stdoutChunks: Buffer[] = [];
+            const stderrChunks: Buffer[] = [];
+
+            squeue.stdout.on('data', chunk => stdoutChunks.push(chunk));
+            squeue.stderr.on('data', chunk => stderrChunks.push(chunk));
+            squeue.on('error', error => reject(error));
+            squeue.on('close', code => {
+                const stdout = Buffer.concat(stdoutChunks).toString();
+                const stderr = Buffer.concat(stderrChunks).toString();
+
+                if (code !== 0) {
+                    reject(new Error(stderr || `squeue exited with code ${code}`));
                 } else if (stderr) {
                     reject(stderr);
                 } else {

--- a/src/test/slurm-wrapper.py
+++ b/src/test/slurm-wrapper.py
@@ -7,7 +7,8 @@ import sys
 parser = ArgumentParser()
 parser.add_argument('--jobfile', type=str, default='/tmp/.jobfile')
 subparsers = parser.add_subparsers(dest='command')
-subparsers.add_parser('sreset')
+sreset_parser = subparsers.add_parser('sreset')
+sreset_parser.add_argument('--jobs', type=int, default=3)
 
 sbatch_parser = subparsers.add_parser('sbatch')
 sbatch_parser.add_argument('script', type=str)
@@ -112,6 +113,23 @@ if args.command == 'sreset':
         Job('123457', 'job2', 'RUNNING', 'batch', '[node1]', 'job2.sbatch', 'job2.out', 'job2.err', '06:00:00', '00:14:39'),
         Job('123458', 'job3', 'PENDING', 'batch', '[]', 'more/job3.job', 'job3.out', 'job3.err', '00:15:00', '00:00:00'),
     ]
+    for i in range(3, args.jobs):
+        job_id = 123456 + i
+        script = f"many-jobs/job{job_id}-{'x' * 240}.sbatch"
+        jobs.append(
+            Job(
+                str(job_id),
+                f"job{job_id}",
+                'PENDING',
+                'batch',
+                '[]',
+                script,
+                f"job{job_id}.out",
+                f"job{job_id}.err",
+                '00:15:00',
+                '00:00:00',
+            )
+        )
     write_jobs(jobs)
 elif args.command == 'sbatch':
     sbatch(args.script)
@@ -124,4 +142,3 @@ elif args.command == 'scontrol':
         scontrol_show(args.field, args.value)
     else:
         raise NotImplementedError
-

--- a/src/test/suite/scheduler.test.ts
+++ b/src/test/suite/scheduler.test.ts
@@ -325,6 +325,22 @@ suite('scheduler.ts tests', () => {
         }
     });
 
+    test('Slurm :: getQueue large output', async function () {
+        /* skip if windows */
+        if (process.platform === 'win32') {
+            this.skip();
+        }
+
+        const jobCount = 5000;
+        assert.doesNotThrow(() => {
+            execSync(`sreset --jobs ${jobCount}`);
+        });
+
+        const slurm = new scheduler.SlurmScheduler();
+        const queue = await slurm.getQueue();
+        assert.strictEqual(queue.length, jobCount);
+    });
+
     test('Slurm :: cancelJob', async function () {
         /* skip if windows */
         if (process.platform === 'win32') {


### PR DESCRIPTION
Addresses #219. Use spawn instead of exec for squeue to avoid the buffer limits of exec.

This appears to be working, but I want to test on a production HPC system before merging.